### PR TITLE
Media Sources open_basedir restriction fix

### DIFF
--- a/core/components/gallery/processors/mgr/item/ajaxupload.php
+++ b/core/components/gallery/processors/mgr/item/ajaxupload.php
@@ -57,7 +57,7 @@ if (!empty($_FILES['qqfile'])) {
 } else {
 
     $length = 10;
-    $tmpDir = MODX_BASE_PATH."core/cache/gallery-tmp/";
+    $tmpDir = MODX_CORE_PATH."cache/gallery-tmp/";
 
     if(!file_exists($tmpDir)) mkdir($tmpDir);
 


### PR DESCRIPTION
I've updated the ajaxupload function to use a folder inside the core/cache directory - this resolves the folder restriction issue.

I also remove the temporary image after it's been used by the media source.

Logging has been tidied also.
