### PR TITLE
Fix for Gallery and 'Access Denied' messages in the MODX Manager

### DIFF
--- a/assets/components/gallery/connector.php
+++ b/assets/components/gallery/connector.php
@@ -47,7 +47,6 @@ if ($_REQUEST['action'] == 'web/phpthumb') {
         if ($modx->user->hasSessionContext($modx->context->get('key'))) {
             $_SERVER['HTTP_MODAUTH'] = $_SESSION["modx.{$modx->context->get('key')}.user.token"];
         } else {
-            $_SESSION["modx.{$modx->context->get('key')}.user.token"] = 0;
             $_SERVER['HTTP_MODAUTH'] = 0;
         }
     } else {

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -143,7 +143,7 @@ class galItem extends xPDOSimpleObject {
 
     public function getPhpThumbUrl() {
         $assetsUrl = $this->xpdo->getOption('gallery.assets_url',null,$this->xpdo->getOption('assets_url',null,MODX_ASSETS_URL).'components/gallery/');
-        $assetsUrl .= 'connector.php?action=web/phpthumb';
+        $assetsUrl .= 'connector.php?action=web/phpthumb&ctx='.$this->xpdo->context->get('key');
         return $assetsUrl;
     }
 


### PR DESCRIPTION
Fix for the 'access denied' messages in the MODX Manager when using Gallery ... tested in multi-context scenarios but would like third parties suffering the issue to test and confirm too before this is merged.
