### PR TITLE
Add support for 'nth' based tpls

### DIFF
--- a/core/components/gallery/elements/snippets/snippet.gallery.php
+++ b/core/components/gallery/elements/snippets/snippet.gallery.php
@@ -131,8 +131,21 @@ foreach ($data['items'] as $item) {
         $plugin->renderItem($itemArray);
     }
 
-    $output[] = $gallery->getChunk($modx->getOption('thumbTpl',$scriptProperties,'galItemThumb'),$itemArray);
     $idx++;
+    
+    $needle = 'thumbTpl_n' . $idx;
+
+    if(empty($tplnth)) {
+      if (in_array($$needle,$scriptProperties,true)) {
+      $itemidx = $idx;
+      $tplnth = 'thumbTpl_n' . $idx;
+      }
+    }
+    if ($idx % $itemidx === 0) {
+      $output[] = $gallery->getChunk($modx->getOption($tplnth,$scriptProperties,'galItemThumbNth'),$itemArray);
+    }else{
+      $output[] = $gallery->getChunk($modx->getOption('thumbTpl',$scriptProperties,'galItemThumb'),$itemArray);
+    }
 }
 $output = implode("\n",$output);
 


### PR DESCRIPTION
Sorry had to move to a different branch, please see previous conversation: https://github.com/modxcms/Gallery/pull/24

I have modified previous pr so that the usage is the same as getResource:

&thumbTpl_nN - Name of a chunk serving as resource template for every Nth resource, for example &thumbTpl_n2=`2nthTpl` would apply to any thumb divisible by 2.

Struggled to understand the way Jason implemented nth tpls in getResources. So not sure how backward compatible this pr version is either. Have a look and let me know what you think.
