### PR TITLE
Let modx configure phpthumb again

### DIFF
--- a/core/components/gallery/model/gallery/galphpthumb.class.php
+++ b/core/components/gallery/model/gallery/galphpthumb.class.php
@@ -228,4 +228,9 @@ class galPhpThumb extends phpThumb {
         }
         return true;
     }
+
+    function DebugMessage($message, $file, $line) {
+        parent::DebugMessage($message, $file, $line);
+        $this->modx->log(modX::LOG_LEVEL_DEBUG, $message);
+    }
 }

--- a/core/components/gallery/processors/web/phpthumb.php
+++ b/core/components/gallery/processors/web/phpthumb.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @var modX $modx
  * @var array $scriptProperties
@@ -9,25 +8,18 @@
  */
 
 /* load phpThumb */
-
-
-if (!class_exists('phpthumb', false)) {
-    if (!$modx->loadClass('phpthumb', MODX_CORE_PATH . 'model/phpthumb/', true, true)) {
-        $modx->log(modX::LOG_LEVEL_ERROR, '[phpThumbOf] Could not load modPhpThumb class.');
-        return '';
-    }
+if (!$modx->loadClass('modPhpThumb',$modx->getOption('core_path').'model/phpthumb/',true,true)) {
+    $modx->log(modX::LOG_LEVEL_ERROR,'[phpThumbOf] Could not load modPhpThumb class.');
+    return '';
 }
-
-
-$debug = $modx->getOption('debug', $scriptProperties, false);
-
-$src = $modx->getOption('src', $scriptProperties, '');
-$src = str_replace('+', '%27', urldecode($src));
+$debug = $modx->getOption('debug',$scriptProperties,false);
+$src = $modx->getOption('src',$scriptProperties,'');
+$src = str_replace('+','%27',urldecode($src));
 
 /* explode tag options */
 $ptOptions = $scriptProperties;
 
-if (empty($ptOptions['f'])) {
+if (empty($ptOptions['f'])){
     $ext = pathinfo($src, PATHINFO_EXTENSION);
     $ext = strtolower($ext);
     switch ($ext) {
@@ -45,66 +37,55 @@ if (empty($ptOptions['f'])) {
 }
 
 /* load phpthumb */
-$assetsPath = $modx->getOption('gallery.assets_path', $scriptProperties, $modx->getOption('assets_path') . 'components/gallery/');
-$cacheDir = $assetsPath . 'cache/';
+$assetsPath = $modx->getOption('gallery.assets_path',$scriptProperties,$modx->getOption('assets_path').'components/gallery/');
+$phpThumb = new modPhpThumb($modx,$ptOptions);
+$cacheDir = $assetsPath.'cache/';
 
 /* check to make sure cache dir is writable */
 if (!is_writable($cacheDir)) {
     if (!$modx->cacheManager->writeTree($cacheDir)) {
-        $modx->log(modX::LOG_LEVEL_ERROR, '[phpThumbOf] Cache dir not writable: ' . $assetsPath . 'cache/');
+        $modx->log(modX::LOG_LEVEL_ERROR,'[phpThumbOf] Cache dir not writable: '.$assetsPath.'cache/');
         return '';
     }
 }
 
+/* do initial setup */
+$phpThumb->initialize();
+$phpThumb->setParameter('config_cache_directory',$assetsPath.'cache/');
+$phpThumb->setParameter('config_allow_src_above_phpthumb',true);
+$phpThumb->setParameter('allow_local_http_src',true);
+$phpThumb->setParameter('config_document_root', $modx->getOption('base_path',null,MODX_BASE_PATH));
+$phpThumb->setCacheDirectory();
+
 /* get absolute url of image */
-if (strpos($src, '/') != 0 && strpos($src, 'http') != 0) {
-    $src = $modx->getOption('base_url') . $src;
+if (strpos($src,'/') != 0 && strpos($src,'http') != 0) {
+    $src = $modx->getOption('base_url').$src;
 } else {
     $src = urldecode($src);
 }
 /* auto-prepend base path if not a URL */
-if (strpos($src, 'http') === false) {
-    $basePath = $modx->getOption('base_path', null, MODX_BASE_PATH);
+if (strpos($src,'http') === false) {
+    $basePath = $modx->getOption('base_path',null,MODX_BASE_PATH);
     if ($basePath != '/') {
-        $src = str_replace(basename($basePath), '', $src);
-        $src = ltrim($src, '/');
-        $src = $basePath . $src;
+        $src = str_replace(basename($basePath),'',$src);
+        $src = ltrim($src,'/');
+        $src = $basePath.$src;
     }
 }
-
-if (!isset($config['modphpthumb'])) { // make sure we get a few relevant system settings
-    $config['modphpthumb'] = array();
-    $config['modphpthumb']['config_allow_src_above_docroot'] = (boolean)$modx->getOption('phpthumb_allow_src_above_docroot', null, false);
-    $config['modphpthumb']['zc'] = $modx->getOption('phpthumb_zoomcrop', null, 0);
-    $config['modphpthumb']['far'] = $modx->getOption('phpthumb_far', null, 'C');
-    $config['modphpthumb']['config_ttf_directory'] = MODX_CORE_PATH . 'model/phpthumb/fonts/';
-    $config['modphpthumb']['config_document_root'] = $modx->getOption('phpthumb_document_root', null, '');
-}
-$phpThumb = new phpthumb(); // unfortunately we have to create a new object for each image!
-foreach ($config['modphpthumb'] as $param => $value) { // add MODX system settings
-    $phpThumb->$param = $value;
-}
-foreach ($ptOptions as $param => $value) { // add options passed to the snippet
-    $phpThumb->setParameter($param, $value);
-}
-// try to avert problems when $_SERVER['DOCUMENT_ROOT'] is different than MODX_BASE_PATH
-if (!$phpThumb->config_document_root) {
-    $phpThumb->config_document_root = MODX_BASE_PATH; // default if nothing set from system settings
-}
-$phpThumb->config_cache_directory = $assetsPath . 'cache/'; // doesn't matter, but saves phpThumb some frustration
-$phpThumb->setSourceFilename($src);
+/* set source */
+$phpThumb->set($src);
 
 /* setup cache filename that is unique to this tag */
-$inputSanitized = str_replace(array(':', '/'), '_', $src);
+$inputSanitized = str_replace(array(':','/'),'_',$src);
 $cacheFilename = $inputSanitized;
-$cacheFilename .= '.' . md5(serialize($scriptProperties));
+$cacheFilename .= '.'.md5(serialize($scriptProperties));
 $cacheFilename .= '.' . (!empty($ptOptions['f']) ? $ptOptions['f'] : 'png');
-$cacheKey = $assetsPath . 'cache/' . $cacheFilename;
+$cacheKey = $assetsPath.'cache/'.$cacheFilename;
 
 /* get cache Url */
-$assetsUrl = $modx->getOption('gallery.assets_url', $scriptProperties, $modx->getOption('assets_url') . 'components/gallery/');
-$cacheUrl = $assetsUrl . 'cache/' . str_replace($cacheDir, '', $cacheKey);
-$cacheUrl = str_replace('//', '/', $cacheUrl);
+$assetsUrl = $modx->getOption('gallery.assets_url',$scriptProperties,$modx->getOption('assets_url').'components/gallery/');
+$cacheUrl = $assetsUrl.'cache/'.str_replace($cacheDir,'',$cacheKey);
+$cacheUrl = str_replace('//','/',$cacheUrl);
 
 /* ensure we have an accurate and clean cache directory */
 $phpThumb->CleanUpCacheDirectory();
@@ -120,7 +101,7 @@ if ($debug) {
     $oldLogTarget = $modx->getLogTarget();
     $oldLogLevel = $modx->getLogLevel();
     $modx->setLogLevel(modX::LOG_LEVEL_DEBUG);
-    $logTarget = $modx->getOption('debugTarget', $scriptProperties, '');
+    $logTarget = $modx->getOption('debugTarget',$scriptProperties,'');
     if (!empty($logTarget)) {
         $modx->setLogTarget();
     }
@@ -128,39 +109,36 @@ if ($debug) {
 
 /* ensure file has proper permissions */
 if (!empty($cacheKey)) {
-    $filePerm = (int)$modx->getOption('new_file_permissions', $scriptProperties, '0664');
+    $filePerm = (int)$modx->getOption('new_file_permissions',$scriptProperties,'0664');
     @chmod($cacheKey, octdec($filePerm));
 }
 if ($debug) {
-    $mtime = microtime();
-    $mtime = explode(" ", $mtime);
-    $mtime = $mtime[1] + $mtime[0];
-    $tend = $mtime;
-    $totalTime = ($tend - $tstart);
-    $totalTime = sprintf("%2.4f s", $totalTime);
+    $mtime= microtime();
+    $mtime= explode(" ", $mtime);
+    $mtime= $mtime[1] + $mtime[0];
+    $tend= $mtime;
+    $totalTime= ($tend - $tstart);
+    $totalTime= sprintf("%2.4f s", $totalTime);
 
-    $modx->log(modX::LOG_LEVEL_DEBUG, "\n<br />Execution time: {$totalTime}\n<br />");
+    $modx->log(modX::LOG_LEVEL_DEBUG,"\n<br />Execution time: {$totalTime}\n<br />");
     $modx->setLogLevel($oldLogLevel);
     $modx->setLogTarget($oldLogTarget);
 }
-$output = $assetsUrl;
-
-
+$output = '';
 /* check to see if there's a cached file of this already */
 if (file_exists($cacheKey)) {
-    $modx->log(modX::LOG_LEVEL_DEBUG, '[phpThumbOf] Using cached file found for thumb: ' . $cacheKey);
-    $output = str_replace(' ', '%20', $cacheUrl);
+    $modx->log(modX::LOG_LEVEL_DEBUG,'[phpThumbOf] Using cached file found for thumb: '.$cacheKey);
+    $output = str_replace(' ','%20',$cacheUrl);
 } else {
     /* actually make the thumbnail */
-    //return $cacheKey;
     if ($phpThumb->GenerateThumbnail()) { // this line is VERY important, do not remove it!
         if ($phpThumb->RenderToFile($cacheKey)) {
-            $output = str_replace(' ', '%20', $cacheUrl);
+            $output = str_replace(' ','%20',$cacheUrl);
         } else {
-            $modx->log(modX::LOG_LEVEL_ERROR, '[phpThumbOf] Could not cache thumb "' . $src . '" to file at: ' . $cacheKey . ' - Debug: ' . print_r($phpThumb->debugmessages, true));
+            $modx->log(modX::LOG_LEVEL_ERROR,'[phpThumbOf] Could not cache thumb "'.$src.'" to file at: '.$cacheKey.' - Debug: '.print_r($phpThumb->debugmessages,true));
         }
     } else {
-        $modx->log(modX::LOG_LEVEL_ERROR, '[phpThumbOf] Could not generate thumbnail: ' . $src . ' - Debug: ' . print_r($phpThumb->debugmessages, true));
+        $modx->log(modX::LOG_LEVEL_ERROR,'[phpThumbOf] Could not generate thumbnail: '.$src.' - Debug: '.print_r($phpThumb->debugmessages,true));
     }
 }
 
@@ -177,5 +155,4 @@ if (!headers_sent()) {
     header('Content-Type: '.phpthumb_functions::ImageTypeToMIMEtype($phpThumb->thumbnailFormat));
     header('Content-Disposition: inline; filename="'.basename($src).'"');
 }
-
 return file_get_contents($cacheKey);


### PR DESCRIPTION
Since commit 092027d6f59b900e810f8943edbd35761ccd2de4 (merged by https://github.com/modxcms/Gallery/pull/30) various configurations are missing. Especially the important cache limit configurations, so the cache would grow until infinity.

You can easily reproduce this with the following line of bash code:

```
for i in {1..5000}; do wget "http://localhost/modx/assets/components/gallery/connector.php?action=web/phpthumb&ctx=web&w=$i&h=$i&zc=1&far=C&q=90&src=%2Fmodx%2F%2Fmodx%2Fassets%2Fgallery%2F3%2F32.jpg" -O /dev/null; done
```

Every Gallery 1.7.0 installation should be vulnerable to this.

Full list of missing settings:
- config_allow_src_above_docroot
- config_cache_maxage
- config_cache_maxsize
- config_cache_maxfiles
- config_error_bgcolor
- config_error_textcolor
- config_error_fontsize
- config_nohotlink_enabled
- config_nohotlink_valid_domains
- config_nohotlink_erase_image
- config_nohotlink_text_message
- config_nooffsitelink_enabled
- config_nooffsitelink_valid_domains
- config_nooffsitelink_require_refer
- config_nooffsitelink_erase_image
- config_nooffsitelink_watermark_src
- config_nooffsitelink_text_message
- cache_source_enabled
- cache_source_directory
- allow_local_http_src
- zc
- far
- cache_directory_depth
- config_ttf_directory

Please consider using the preconfigured modPhpThumb again. Alternatively there is still the older galPhpThumb left here (which should be removed if it's unused).

Another way could be replacing the phpthumb processor by using user defined snippets like [[phpThumbsUp]] which would also prevent duplicated cache entries caused by using them together with Gallery. Whats the reason for an own cache folder, why not using the default cache folder provided by the system instead? 
