### PR TITLE
revert backend_thumb_height to 100

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -39,7 +39,7 @@ $settings['gallery.backend_thumb_far']->fromArray(array(
 $settings['gallery.backend_thumb_height']= $modx->newObject('modSystemSetting');
 $settings['gallery.backend_thumb_height']->fromArray(array(
     'key' => 'gallery.backend_thumb_height',
-    'value' => '80',
+    'value' => '100',
     'xtype' => 'textfield',
     'namespace' => 'gallery',
     'area' => 'backend',


### PR DESCRIPTION
I'm not sure if I'm missing something here but the change of the default system setting for thumb height made in https://github.com/modxcms/Gallery/commit/1c3433192a5915da7ba46486953b7d84ca22fa8b from 100 to 80 just seem off to me. It just looks like the image did not load properly since the outer box is 100px. So I'll suggest a revert back to a hight of 100px.

See pic, manualy changed the url to get a 100px high image for the first one.
![003_selection](https://cloud.githubusercontent.com/assets/1887628/4346261/d63134f8-40f4-11e4-94d1-962d88f724bf.png)

This was tested on a clean modx 2.3.1-pl install with Gallery 1.7.0-pl from the Package Manager "Installed on Sep 20, 2014 06:21 PM"
