### PR TITLE
Fix nonaggregated column in SELECT list when showing gallery items

### DIFF
--- a/core/components/gallery/processors/mgr/item/getlist.class.php
+++ b/core/components/gallery/processors/mgr/item/getlist.class.php
@@ -62,7 +62,6 @@ class GalleryItemGetListProcessor extends modObjectGetListProcessor {
                 WHERE Tags.item = galItem.id
             ) AS tags'
         ));
-        $c->groupBy('id');
         return $c;
     }
 


### PR DESCRIPTION
```Expression #13 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'premium.AlbumItems.rank' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by```

By not using the groupby (which does not seem to be necessary, not even when multiple tags exist for an image) this stops triggering the MySQL 5.7 default mode only_full_group_by. 