### PR TITLE
Fix Multi-Upload (2.0.0-pl)

### DIFF
--- a/core/components/gallery/model/gallery/galalbum.class.php
+++ b/core/components/gallery/model/gallery/galalbum.class.php
@@ -222,6 +222,7 @@ class galAlbum extends xPDOSimpleObject {
         if(!is_uploaded_file($filePath) && get_class($mediaSource) == 'modFileMediaSource_mysql') {
             $input = fopen($filePath, "r");
             $target = fopen($this->getPath().$shortName, "w");
+            $bytes = stream_copy_to_stream($input, $target);	
             fclose($input);
             fclose($target);
         } else {


### PR DESCRIPTION
I think this line was accidentally deleted in the version 2.0.0 update.

Now the Multi-Upload doesn't work correctly anymore as the data isn't copied from the temporary directory (`core/cache/gallery-tmp`) to the gallery directory (`assets/gallery`).

https://community.modx.com/t/gallery-2-0-multiupload-dont-work-element-upload-ok/5504