### PR TITLE
Fix SQL queries with "rank" in MySQL 8

### DIFF
--- a/core/components/gallery/elements/tv/input/galleryalbumlist.class.php
+++ b/core/components/gallery/elements/tv/input/galleryalbumlist.class.php
@@ -65,7 +65,10 @@ class GalleryAlbumListInputRender extends modTemplateVarInputRender
         if (empty($params)) $params = array();
 
         /* setup default properties */
-        $sort = $this->modx->getOption('sort',$params,'rank');
+        $sort = $this->modx->getOption('sort',$params,'`rank`');
+        if (strtolower($sort) == 'rank'){
+            $sort = '`rank`';
+        }
         $dir = $this->modx->getOption('dir',$params,'ASC');
         $limit = (int)$this->modx->getOption('limit',$params,0);
         $start = (int)$this->modx->getOption('start',$params,0);
@@ -125,7 +128,7 @@ class GalleryAlbumListInputRender extends modTemplateVarInputRender
                 $c->where(array(
                     'AlbumItems.album' => $album->get('id'),
                 ));
-                $c->sortby('rank','ASC');
+                $c->sortby('`rank`','ASC');
                 $c->limit(1);
                 $coverItem = $this->modx->getObject('galItem',$c);
             }

--- a/core/components/gallery/model/gallery/galalbum.class.php
+++ b/core/components/gallery/model/gallery/galalbum.class.php
@@ -139,9 +139,9 @@ class galAlbum extends xPDOSimpleObject {
 
         $movingDown = $newRank > $oldRank;
         if ($movingDown) {
-            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbum').' SET rank = rank - 1 WHERE rank >= '.$oldRank.' AND rank <= '.$newRank.' AND parent = '.$this->get('parent');
+            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbum').' SET `rank` = `rank` - 1 WHERE `rank` >= '.$oldRank.' AND `rank` <= '.$newRank.' AND parent = '.$this->get('parent');
         } else {
-            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbum').' SET rank = rank + 1 WHERE rank > '.$newRank.' AND rank <= '.$oldRank.' AND parent = '.$this->get('parent');
+            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbum').' SET `rank` = `rank` + 1 WHERE `rank` > '.$newRank.' AND `rank` <= '.$oldRank.' AND parent = '.$this->get('parent');
         }
         $this->xpdo->exec($sql);
 
@@ -166,7 +166,7 @@ class galAlbum extends xPDOSimpleObject {
 
         if ($moved) {
             /* Recalculate ranks of old parent */
-            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbum').' SET rank = rank - 1 WHERE rank >= '.$oldRank.' AND parent = '.$oldParent;
+            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbum').' SET `rank` = `rank` - 1 WHERE `rank` >= '.$oldRank.' AND parent = '.$oldParent;
             $this->xpdo->exec($sql);
         }
         return $moved;
@@ -425,7 +425,10 @@ class galAlbum extends xPDOSimpleObject {
                 $albums[] = $album;
             }
         } else {
-            $sort = $modx->getOption('sort',$scriptProperties,'rank');
+            $sort = $modx->getOption('sort',$scriptProperties,'`rank`');
+            if (strtolower($sort) == 'rank'){
+                $sort = '`rank`';
+            }
             $dir = $modx->getOption('dir',$scriptProperties,'DESC');
             $limit = $modx->getOption('limit',$scriptProperties,10);
             $start = $modx->getOption('start',$scriptProperties,0);

--- a/core/components/gallery/model/gallery/galalbumitem.class.php
+++ b/core/components/gallery/model/gallery/galalbumitem.class.php
@@ -29,9 +29,9 @@ class galAlbumItem extends xPDOSimpleObject {
         $this->set('rank',$newRank);
         $movingDown = $newRank > $oldRank;
         if ($movingDown) {
-            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbumItem').' SET rank = rank - 1 WHERE rank >= '.$oldRank.' AND rank <= '.$newRank.' AND album = '.$this->get('album');
+            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbumItem').' SET `rank` = `rank` - 1 WHERE `rank` >= '.$oldRank.' AND `rank` <= '.$newRank.' AND album = '.$this->get('album');
         } else {
-            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbumItem').' SET rank = rank + 1 WHERE rank >= '.$newRank.' AND rank <= '.$oldRank.' AND album = '.$this->get('album');
+            $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbumItem').' SET `rank` = `rank` + 1 WHERE `rank` >= '.$newRank.' AND `rank` <= '.$oldRank.' AND album = '.$this->get('album');
         }
         $this->xpdo->exec($sql);
         return $this->save();

--- a/core/components/gallery/model/gallery/galitem.class.php
+++ b/core/components/gallery/model/gallery/galitem.class.php
@@ -279,7 +279,7 @@ class galItem extends xPDOSimpleObject {
         }
 
         /* fix old album ranks */
-        $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbumItem').' SET rank = rank - 1 WHERE rank >= '.$oldRank.' AND album = '.$oldAlbum;
+        $sql = 'UPDATE '.$this->xpdo->getTableName('galAlbumItem').' SET `rank` = `rank` - 1 WHERE `rank` >= '.$oldRank.' AND album = '.$oldAlbum;
         $this->xpdo->exec($sql);
 
         /* move actual file */

--- a/core/components/gallery/model/gallery/galleryalbumsmediasource.class.php
+++ b/core/components/gallery/model/gallery/galleryalbumsmediasource.class.php
@@ -34,7 +34,7 @@ class GalleryAlbumsMediaSource extends modMediaSource implements modMediaSourceI
             } else {
                 $c = $this->xpdo->newQuery('galAlbum');
                 $c->where(array('parent' => 0));
-                $c->sortby('rank','ASC');
+                $c->sortby('`rank`','ASC');
                 $albums = $this->xpdo->getCollection('galAlbum',$c);
                 /** @var galAlbum $album */
                 foreach ($albums as $album) {
@@ -57,7 +57,7 @@ class GalleryAlbumsMediaSource extends modMediaSource implements modMediaSourceI
 
             $c = $this->xpdo->newQuery('galAlbum');
             $c->where(array('parent' => $id));
-            $c->sortby('rank','ASC');
+            $c->sortby('`rank`','ASC');
             $albums = $this->xpdo->getCollection('galAlbum',$c);
             /** @var galAlbum $album */
             foreach ($albums as $album) {

--- a/core/components/gallery/model/gallery/mysql/galalbum.map.inc.php
+++ b/core/components/gallery/model/gallery/mysql/galalbum.map.inc.php
@@ -36,7 +36,7 @@ $xpdo_meta_map['galAlbum']= array (
     'name' => 
     array (
       'dbtype' => 'varchar',
-      'precision' => '255',
+      'precision' => '250',
       'phptype' => 'string',
       'null' => false,
       'default' => '',

--- a/core/components/gallery/model/gallery/mysql/galtag.map.inc.php
+++ b/core/components/gallery/model/gallery/mysql/galtag.map.inc.php
@@ -27,7 +27,7 @@ $xpdo_meta_map['galTag']= array (
     'tag' => 
     array (
       'dbtype' => 'varchar',
-      'precision' => '255',
+      'precision' => '250',
       'phptype' => 'string',
       'null' => false,
       'default' => '',

--- a/core/components/gallery/model/schema/gallery.mysql.schema.xml
+++ b/core/components/gallery/model/schema/gallery.mysql.schema.xml
@@ -38,7 +38,7 @@
     -->
     <object class="galAlbum" table="gallery_albums" extends="xPDOSimpleObject">
         <field key="parent" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="index" />
-        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="name" dbtype="varchar" precision="250" phptype="string" null="false" default="" index="index" />
         <field key="year" dbtype="varchar" precision="255" phptype="string" />
         <field key="description" dbtype="text" phptype="string" />
         <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
@@ -120,7 +120,7 @@
     -->
     <object class="galTag" table="gallery_tags" extends="xPDOSimpleObject">
         <field key="item" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
-        <field key="tag" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="tag" dbtype="varchar" precision="250" phptype="string" null="false" default="" index="index" />
 
         <index alias="item" name="item" primary="false" unique="false" type="BTREE">
             <column key="item" length="" collation="A" null="false" />

--- a/core/components/gallery/processors/mgr/item/getlist.class.php
+++ b/core/components/gallery/processors/mgr/item/getlist.class.php
@@ -28,7 +28,7 @@
 class GalleryItemGetListProcessor extends modObjectGetListProcessor {
     public $classKey = 'galItem';
     public $objectType = 'gallery.item';
-    public $defaultSortField = 'rank';
+    public $defaultSortField = '`rank`';
     public $defaultSortDirection = 'ASC';
     public $languageTopics = array('gallery:default');
 
@@ -63,7 +63,7 @@ class GalleryItemGetListProcessor extends modObjectGetListProcessor {
             ) AS tags'
         ));
         $c->groupBy('id');
-        $c->groupBy('rank');
+        $c->groupBy('`rank`');
         return $c;
     }
 

--- a/core/components/gallery/processors/mgr/item/sort.class.php
+++ b/core/components/gallery/processors/mgr/item/sort.class.php
@@ -46,22 +46,22 @@ class GalleryItemSortProcessor extends modProcessor {
         if ($source->get('rank') < $target->get('rank')) {
             $modx->exec("
                 UPDATE {$modx->getTableName('galAlbumItem')}
-                    SET rank = rank - 1
+                    SET `rank` = `rank` - 1
                 WHERE
                     album = ".$scriptProperties['album']."
-                AND rank < {$target->get('rank')}
-                AND rank > {$source->get('rank')}
-                AND rank > 0
+                AND `rank` < {$target->get('rank')}
+                AND `rank` > {$source->get('rank')}
+                AND `rank` > 0
             ");
             $newRank = $target->get('rank')-1;
         } else {
             $modx->exec("
                 UPDATE {$modx->getTableName('galAlbumItem')}
-                    SET rank = rank + 1
+                    SET `rank` = `rank` + 1
                 WHERE
                     album = ".$scriptProperties['album']."
-                AND rank >= {$target->get('rank')}
-                AND rank < {$source->get('rank')}
+                AND `rank` >= {$target->get('rank')}
+                AND `rank` < {$source->get('rank')}
             ");
             $newRank = $target->get('rank');
         }

--- a/core/components/gallery/src/Model/GalleryAlbumsMediaSource.php
+++ b/core/components/gallery/src/Model/GalleryAlbumsMediaSource.php
@@ -49,7 +49,7 @@ class GalleryAlbumsMediaSource extends modMediaSource
             } else {
                 $c = $this->xpdo->newQuery('galAlbum');
                 $c->where(array('parent' => 0));
-                $c->sortby('rank','ASC');
+                $c->sortby('`rank`','ASC');
                 $albums = $this->xpdo->getCollection('galAlbum',$c);
                 /** @var galAlbum $album */
                 foreach ($albums as $album) {
@@ -72,7 +72,7 @@ class GalleryAlbumsMediaSource extends modMediaSource
 
             $c = $this->xpdo->newQuery('galAlbum');
             $c->where(array('parent' => $id));
-            $c->sortby('rank','ASC');
+            $c->sortby('`rank`','ASC');
             $albums = $this->xpdo->getCollection('galAlbum',$c);
             /** @var galAlbum $album */
             foreach ($albums as $album) {


### PR DESCRIPTION
In MySQL 8 **RANK** is a reserved keyword.
Because both classes **galAlbum** and **galAlbumItem** have a field called "rank", there are SQL queries that fail.
This PR should fix it.

Related forum topic:
https://community.modx.com/t/solved-problem-persists-with-gallery-2-0-0-not-displaying-images-in-manager/5558