### PR TITLE
Fix schema for utf8mb4

### DIFF
--- a/core/components/gallery/model/gallery/mysql/galalbum.map.inc.php
+++ b/core/components/gallery/model/gallery/mysql/galalbum.map.inc.php
@@ -36,7 +36,7 @@ $xpdo_meta_map['galAlbum']= array (
     'name' => 
     array (
       'dbtype' => 'varchar',
-      'precision' => '255',
+      'precision' => '250',
       'phptype' => 'string',
       'null' => false,
       'default' => '',

--- a/core/components/gallery/model/gallery/mysql/galtag.map.inc.php
+++ b/core/components/gallery/model/gallery/mysql/galtag.map.inc.php
@@ -27,7 +27,7 @@ $xpdo_meta_map['galTag']= array (
     'tag' => 
     array (
       'dbtype' => 'varchar',
-      'precision' => '255',
+      'precision' => '250',
       'phptype' => 'string',
       'null' => false,
       'default' => '',

--- a/core/components/gallery/model/schema/gallery.mysql.schema.xml
+++ b/core/components/gallery/model/schema/gallery.mysql.schema.xml
@@ -38,7 +38,7 @@
     -->
     <object class="galAlbum" table="gallery_albums" extends="xPDOSimpleObject">
         <field key="parent" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="index" />
-        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="name" dbtype="varchar" precision="250" phptype="string" null="false" default="" index="index" />
         <field key="year" dbtype="varchar" precision="255" phptype="string" />
         <field key="description" dbtype="text" phptype="string" />
         <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
@@ -120,7 +120,7 @@
     -->
     <object class="galTag" table="gallery_tags" extends="xPDOSimpleObject">
         <field key="item" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
-        <field key="tag" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="tag" dbtype="varchar" precision="250" phptype="string" null="false" default="" index="index" />
 
         <index alias="item" name="item" primary="false" unique="false" type="BTREE">
             <column key="item" length="" collation="A" null="false" />


### PR DESCRIPTION
The fields "name" (galAlbum) and "tag" (galTag) are too big for an index if a utf8mb4 character set is used.

It creates error messages (`Specified key was too long; max key length is 1000 bytes`) during the installation and both database tables are not created.