### PR TITLE
2.0.3 issue version data on album/getnodes.class.php

### DIFF
--- a/assets/components/gallery/css/mgr.css
+++ b/assets/components/gallery/css/mgr.css
@@ -4,7 +4,7 @@
     width: 4px;
 }
 .gal-item-inactive {
-    opacity: 0.5;
+    opacity: 0.5 !important;
 }
 /* unnecessary as defined in default styles */
 /*.green { color: green; }

--- a/core/components/gallery/processors/mgr/album/getnodes.class.php
+++ b/core/components/gallery/processors/mgr/album/getnodes.class.php
@@ -53,10 +53,10 @@ class GalleryAlbumGetNodesProcessor extends modObjectProcessor {
             $albumArray['parent'] = 0;
 
             $version = $this->modx->getVersionData();
-            if ($version['major_version'] < 3) {
+            if ($version['version'] < 3) {
                 $albumArray['cls'] = 'icon-tiff'.($album->get('active') ? '' : ' gal-item-inactive');
             } else {
-                $albumArray['iconCls'] = 'icon icon-tiff'.($album->get('active') ? '' : ' gal-item-inactive');
+                $albumArray['iconCls'] = 'icon-tiff'.($album->get('active') ? '' : ' gal-item-inactive');
             }
 
             $albumArray['classKey'] = 'galAlbum';


### PR DESCRIPTION
In getNodes, check major_version and not version, for MODX

Furthermore:

In V2
index ['cls'] go to icon

In V3
index ['iconCls'] go to icon
and
index ['cls'] go to div container

The change is for general but in my dev i add class for div and class for prominent
```
$version = $this->modx->getVersionData();
if ($version['version'] < 3) {
       $albumArray['cls'] = 'icon-tiff'.($album->get('active') ? '' : ' gal-item-inactive');
} else {
	//MABOL, aggiunta classe per differenziare album preminenti oppure no, e modificata classe icona e classe div
	$albumArray['cls'] = ' '.($album->get('active') ? '' : ' gal-item-inactive');
        $albumArray['iconCls'] = 'icon-tiff'.($album->get('active') ? '' : ' icon-gal-item-inactive');
			
	if($album->get('prominent')){	
		$albumArray['cls'] .= ' gal-item-prominent';	
		$albumArray['iconCls'] .= ' icon-gal-item-prominent';	
	}
}
```