### PR TITLE
Fix pagination for custom page size

### DIFF
--- a/assets/components/gallery/js/mgr/tv/gal.browser.js
+++ b/assets/components/gallery/js/mgr/tv/gal.browser.js
@@ -31,7 +31,7 @@ GAL.BrowserWindow = function(config) {
         ,listeners: {'select':{fn:this.onSelect,scope:this}}
     });
     this.view.pagingBar = new Ext.PagingToolbar({
-        pageSize: 24
+        pageSize: config.pageSize || (parseInt(MODx.config.default_per_page) || 24)
         ,store: this.view.store
         ,displayInfo: true
         ,autoLoad: true

--- a/assets/components/gallery/js/mgr/widgets/album/album.items.view.js
+++ b/assets/components/gallery/js/mgr/widgets/album/album.items.view.js
@@ -10,6 +10,8 @@ GAL.view.AlbumItems = function(config) {
         ,baseParams: {
             action: 'mgr/item/getlist'
             ,album: config.album
+            ,start: 0
+            ,limit: config.pageSize || (parseInt(MODx.config.default_per_page) || 24)
         }
         ,loadingText: _('loading')
         ,tpl: this.templates.thumb
@@ -293,4 +295,3 @@ Ext.extend(GAL.view.AlbumItems,MODx.DataView,{
     }
 });
 Ext.reg('gal-view-album-items',GAL.view.AlbumItems);
-

--- a/assets/components/gallery/js/mgr/widgets/album/album.panel.js
+++ b/assets/components/gallery/js/mgr/widgets/album/album.panel.js
@@ -234,7 +234,7 @@ GAL.panel.AlbumItems = function(config) {
             ,_('per_page')+':'
             ,{
                 xtype: 'textfield'
-                ,value: config.pageSize || (parseInt(MODx.config.default_per_page) || 20)
+                ,value: config.pageSize || (parseInt(MODx.config.default_per_page) || 24)
                 ,width: 40
                 ,listeners: {
                     'change': {fn:function(tf,nv,ov) {


### PR DESCRIPTION
If the system setting `default_per_page` contains a value that is different from the default (= `20`), then the wrong number of items are shown when editing an album (and the display in the paging-toolbar is incorrect).

Fixes the issues #68 and #107.