### PR TITLE
Fix thumbnails in MediaSource of type "Gallery Albums"

### DIFF
--- a/core/components/gallery/model/gallery/galleryalbumsmediasource.class.php
+++ b/core/components/gallery/model/gallery/galleryalbumsmediasource.class.php
@@ -180,6 +180,15 @@ class GalleryAlbumsMediaSource extends modMediaSource implements modMediaSourceI
                     'fullRelativeUrl' => $itemArray['relativeImage'],
                 );
             }
+
+            $modx_version = $this->xpdo->getVersionData();
+            if (version_compare($modx_version['full_version'], '2.8.0-pl') >= 0) {
+                // For MODX versions newer or equal to 2.8.0, undo any ampersand encoding (as it will be done in JS)
+                $list = array_map(function($item) {
+                    $item['thumb'] = str_replace('&amp;', '&', $item['thumb']);
+                    return $item;
+                }, $list);
+            }
         }
         return $list;
     }

--- a/core/components/gallery/src/Model/GalleryAlbumsMediaSource.php
+++ b/core/components/gallery/src/Model/GalleryAlbumsMediaSource.php
@@ -187,12 +187,13 @@ class GalleryAlbumsMediaSource extends modMediaSource
                     'image' => $item->get('image'),
                     'image_width' => $imageWidth,
                     'image_height' => $imageHeight,
-                    'thumb' => $item->get('thumbnail'),
+                    'thumb' => str_replace('&amp;', '&', $item->get('thumbnail')),
                     'thumb_width' => $thumbWidth,
                     'thumb_height' => $thumbHeight,
                     'url' => $itemArray['image'],
                     'relativeUrl' => $itemArray['relativeImage'],
                     'fullRelativeUrl' => $itemArray['relativeImage'],
+                    'preview' => 1
                 );
             }
         }


### PR DESCRIPTION
If a MediaSource of "Source Type" = `Gallery Albums` is created, the URLs for the thumbnails in the media browser are not correct anymore.

Due to a change to the MODX media browser (https://github.com/modxcms/revolution/pull/15273 for MODX 2.x, https://github.com/modxcms/revolution/pull/15273 for MODX 3.x), an ampersand in the URL gets HTML-encoded twice.

---

Related discussion in the MODX forum: https://community.modx.com/t/gallery-thumbnails-broken-in-manager/8643